### PR TITLE
feat: add FilmUrl model

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,8 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.projectlombok:lombok'
+	testCompileOnly 'org.projectlombok:lombok'
+	testAnnotationProcessor 'org.projectlombok:lombok'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'io.projectreactor:reactor-test'

--- a/src/test/java/com/filmfest/film/model/FilmUrl.java
+++ b/src/test/java/com/filmfest/film/model/FilmUrl.java
@@ -1,0 +1,22 @@
+package com.filmfest.film.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document(collection = "film_urls")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FilmUrl {
+    @Id
+    private String id;
+
+    private String fullUrlCa;
+    private String fullUrlEs;
+    private String fullUrlEn;
+}


### PR DESCRIPTION
### feat: add FilmUrl model

Represents a document in the film_urls MongoDB collection. It stores the detail page URLs of a film in three languages.