### PR TITLE
feat: add FilmUrl repository for MongoDB

### DIFF
--- a/src/main/java/com/filmfest/film/repository/FilmUrlRepository.java
+++ b/src/main/java/com/filmfest/film/repository/FilmUrlRepository.java
@@ -1,0 +1,7 @@
+package com.filmfest.film.repository;
+
+import com.filmfest.film.model.FilmUrl;
+import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
+
+public interface FilmUrlRepository extends ReactiveMongoRepository<FilmUrl, String> {
+}


### PR DESCRIPTION
This interface enables reactive access to the film_urls collection in MongoDB using Spring Data.

By extending ReactiveMongoRepository, this repository automatically provides reactive CRUD operations, including:
- Mono<FilmUrl> findById(String id)
- Flux<FilmUrl> findAll()
- Mono<FilmUrl> save(FilmUrl entity)
- Mono<Void> deleteById(String id)

No custom queries defined yet.