### PR TITLE
feat: add FilmUrl dto

### DIFF
--- a/src/main/java/com/filmfest/film/dto/FilmUrlDto.java
+++ b/src/main/java/com/filmfest/film/dto/FilmUrlDto.java
@@ -1,0 +1,14 @@
+package com.filmfest.film.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class FilmUrlDto {
+    private String id;
+
+    private String fullUrlCa;
+    private String fullUrlEn;
+    private String fullUrlEs;
+}


### PR DESCRIPTION
Adds a DTO class to encapsulate the data of a FilmUrl entity, typically used for external API responses or internal data transfer without exposing the full model.