### PR TITLE
feat: add WebClient config

### DIFF
--- a/src/main/java/com/filmfest/film/config/WebClientConfig.java
+++ b/src/main/java/com/filmfest/film/config/WebClientConfig.java
@@ -1,0 +1,18 @@
+package com.filmfest.film.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+    private static final String BASE_URL = "https://sitgesfilmfestival.com";
+
+    @Bean
+    public WebClient sitgesWebClient() {
+        return WebClient.builder()
+                .baseUrl(BASE_URL)
+                .codecs(config -> config.defaultCodecs().maxInMemorySize(5 * 1024 * 1024))
+                .build();
+    }
+}


### PR DESCRIPTION
This pull request introduces a centralized configuration for WebClient to interact with the Filmfest API. It defines a reusable WebClient bean with a predefined baseUrl and memory buffer settings, improving modularity and reusability across services.