### PR TITLE
feat: add service layer

### DIFF
--- a/src/main/java/com/filmfest/film/service/FilmUrlExtractionService.java
+++ b/src/main/java/com/filmfest/film/service/FilmUrlExtractionService.java
@@ -1,0 +1,8 @@
+package com.filmfest.film.service;
+
+import com.filmfest.film.dto.FilmUrlDto;
+import reactor.core.publisher.Flux;
+
+public interface FilmUrlExtractionService {
+    Flux<FilmUrlDto> extractFilmUrls(String rawJson);
+}

--- a/src/main/java/com/filmfest/film/service/FilmUrlScraperService.java
+++ b/src/main/java/com/filmfest/film/service/FilmUrlScraperService.java
@@ -1,0 +1,7 @@
+package com.filmfest.film.service;
+
+import reactor.core.publisher.Flux;
+
+public interface FilmUrlScraperService {
+    Flux<String> scrapeRawJson(int year);
+}

--- a/src/main/java/com/filmfest/film/service/FilmUrlService.java
+++ b/src/main/java/com/filmfest/film/service/FilmUrlService.java
@@ -1,0 +1,2 @@
+package com.filmfest.film.service;public class FilmUrlService {
+}

--- a/src/main/java/com/filmfest/film/service/FilmUrlService.java
+++ b/src/main/java/com/filmfest/film/service/FilmUrlService.java
@@ -1,2 +1,10 @@
-package com.filmfest.film.service;public class FilmUrlService {
+package com.filmfest.film.service;
+
+import com.filmfest.film.dto.FilmUrlDto;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public interface FilmUrlService {
+    Mono<FilmUrlDto> save(FilmUrlDto filmUrlDto);
+    Flux<FilmUrlDto> findAll();
 }

--- a/src/main/java/com/filmfest/film/service/impl/FilmUrlExtractionServiceImpl.java
+++ b/src/main/java/com/filmfest/film/service/impl/FilmUrlExtractionServiceImpl.java
@@ -1,0 +1,49 @@
+package com.filmfest.film.service.impl;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.filmfest.film.dto.FilmUrlDto;
+import com.filmfest.film.service.FilmUrlExtractionService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class FilmUrlExtractionServiceImpl implements FilmUrlExtractionService {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private static final String BASE_URL = "https://sitgesfilmfestival.com";
+
+
+    @Override
+    public Flux<FilmUrlDto> extractFilmUrls(String rawJson) {
+        try {
+            JsonNode root = objectMapper.readTree(rawJson);
+            List<FilmUrlDto> filmUrlList = new ArrayList<>();
+
+            for (JsonNode node : root) {
+                String urlCa = node.path("url_ca").asText();
+                String urlEs = node.path("url_es").asText();
+                String urlEn = node.path("url_en").asText();
+
+                filmUrlList.add(FilmUrlDto.builder()
+                        .fullUrlCa(BASE_URL + "/ca/film/" + urlCa)
+                        .fullUrlEs(BASE_URL + "/es/film/" + urlEs)
+                        .fullUrlEn(BASE_URL + "/en/film/" + urlEn)
+                        .build());
+            }
+
+            return Flux.fromIterable(filmUrlList);
+
+        } catch (Exception e) {
+            log.error("Failed to parse film URLs", e);
+            return Flux.error(e);
+        }
+    }
+}

--- a/src/main/java/com/filmfest/film/service/impl/FilmUrlScraperServiceImpl.java
+++ b/src/main/java/com/filmfest/film/service/impl/FilmUrlScraperServiceImpl.java
@@ -1,0 +1,26 @@
+package com.filmfest.film.service.impl;
+
+import com.filmfest.film.service.FilmUrlScraperService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
+
+@Service
+@RequiredArgsConstructor
+public class FilmUrlScraperServiceImpl implements FilmUrlScraperService {
+
+    private static final String BASE_URL = "https://sitgesfilmfestival.com";
+    private static final String BASE_ENDPOINT = BASE_URL + "/service/films/";
+
+    private final WebClient sitgesWebClient;
+
+    @Override
+    public Flux<String> scrapeRawJson(int year) {
+        return sitgesWebClient.get()
+                .uri(BASE_ENDPOINT)
+                .retrieve()
+                .bodyToMono(String.class)
+                .flatMapMany(json -> Flux.just(json));
+    }
+}

--- a/src/main/java/com/filmfest/film/service/impl/FilmUrlServiceImpl.java
+++ b/src/main/java/com/filmfest/film/service/impl/FilmUrlServiceImpl.java
@@ -1,0 +1,2 @@
+package com.filmfest.film.service.impl;public class FilmUrlServiceImpl {
+}

--- a/src/main/java/com/filmfest/film/service/impl/FilmUrlServiceImpl.java
+++ b/src/main/java/com/filmfest/film/service/impl/FilmUrlServiceImpl.java
@@ -1,2 +1,31 @@
-package com.filmfest.film.service.impl;public class FilmUrlServiceImpl {
+package com.filmfest.film.service.impl;
+
+import com.filmfest.film.dto.FilmUrlDto;
+import com.filmfest.film.mapper.FilmUrlMapper;
+import com.filmfest.film.model.FilmUrl;
+import com.filmfest.film.repository.FilmUrlRepository;
+import com.filmfest.film.service.FilmUrlService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class FilmUrlServiceImpl implements FilmUrlService {
+
+    private final FilmUrlRepository filmUrlRepository;
+
+    @Override
+    public Mono<FilmUrlDto> save(FilmUrlDto filmUrlDto) {
+        FilmUrl entity = FilmUrlMapper.toEntity(filmUrlDto);
+        return filmUrlRepository.save(entity)
+                .map(FilmUrlMapper::toDto);
+    }
+
+    @Override
+    public Flux<FilmUrlDto> findAll() {
+        return filmUrlRepository.findAll()
+                .map(FilmUrlMapper::toDto);
+    }
 }


### PR DESCRIPTION
This pull request introduces the core service layer for handling film URL data. It separates responsibilities between scraping external data, extracting relevant information, and managing persistence logic.

### Changes

Added Interfaces: 

- FilmUrlService: Defines operations for saving and retrieving FilmUrlDto objects.
- FilmUrlScraper: Abstracts external API call to Film Festival endpoint.
- FilmUrlExtractionService: Parses raw JSON into a list of structured FilmUrlDto objects.

Added Implementations: 

- FilmUrlServiceImpl: Uses FilmUrlRepository and FilmUrlMapper to persist and retrieve data.
- FilmUrlScraperImpl: Uses WebClient to fetch raw JSON data for a specific festival year.
- FilmUrlExtractionServiceImpl: Uses ObjectMapper to transform JSON into usable DTOs.

